### PR TITLE
data: rename non-slug interface keys to URL-friendly slugs

### DIFF
--- a/data/aionlabs/services/aion-1.0-mini/listing.json
+++ b/data/aionlabs/services/aion-1.0-mini/listing.json
@@ -107,7 +107,7 @@
   "status": "ready",
   "time_created": "2025-08-21T00:00:00Z",
   "user_access_interfaces": {
-    "Provider API": {
+    "provider_api": {
       "access_method": "http",
       "base_url": "${API_GATEWAY_BASE_URL}/p/aionlabs",
       "routing_key": {

--- a/data/aionlabs/services/aion-1.0-mini/offering.json
+++ b/data/aionlabs/services/aion-1.0-mini/offering.json
@@ -23,7 +23,7 @@
   ],
   "time_created": "2025-08-21T00:00:00Z",
   "upstream_access_config": {
-    "Aion Labs API": {
+    "aion_labs_api": {
       "access_method": "http",
       "api_key": "${ secrets.AIONLABS_API_KEY }",
       "base_url": "https://api.aionlabs.ai/v1",

--- a/data/aionlabs/services/aion-1.0/listing.json
+++ b/data/aionlabs/services/aion-1.0/listing.json
@@ -107,7 +107,7 @@
   "status": "ready",
   "time_created": "2025-08-21T00:00:00Z",
   "user_access_interfaces": {
-    "Provider API": {
+    "provider_api": {
       "access_method": "http",
       "base_url": "${API_GATEWAY_BASE_URL}/p/aionlabs",
       "routing_key": {

--- a/data/aionlabs/services/aion-1.0/offering.json
+++ b/data/aionlabs/services/aion-1.0/offering.json
@@ -23,7 +23,7 @@
   ],
   "time_created": "2025-08-21T00:00:00Z",
   "upstream_access_config": {
-    "Aion Labs API": {
+    "aion_labs_api": {
       "access_method": "http",
       "api_key": "${ secrets.AIONLABS_API_KEY }",
       "base_url": "https://api.aionlabs.ai/v1",

--- a/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
+++ b/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
@@ -106,7 +106,7 @@
   "status": "ready",
   "time_created": "2025-07-15T00:00:00Z",
   "user_access_interfaces": {
-    "Provider API": {
+    "provider_api": {
       "access_method": "http",
       "base_url": "${API_GATEWAY_BASE_URL}/p/aionlabs",
       "routing_key": {

--- a/data/aionlabs/services/aion-rp-llama-3.1-8b/offering.json
+++ b/data/aionlabs/services/aion-rp-llama-3.1-8b/offering.json
@@ -23,7 +23,7 @@
   ],
   "time_created": "2025-07-15T00:00:00Z",
   "upstream_access_config": {
-    "Aion Labs API": {
+    "aion_labs_api": {
       "access_method": "http",
       "api_key": "${ secrets.AIONLABS_API_KEY }",
       "base_url": "https://api.aionlabs.ai/v1",


### PR DESCRIPTION
## Summary

Renames the keys of \`upstream_access_config\` (offering files) and \`user_access_interfaces\` (listing files) so they conform to the slug pattern (\`^[a-z0-9][a-z0-9_-]*$\`) the unitysvc backend now enforces on \`AccessInterface.name\`.

Renames in this repo:
- \`user_access_interfaces\`: \`"Provider API"\` → \`provider_api\`
- \`upstream_access_config\`: \`"Aion Labs API"\` → \`aion_labs_api\`

Values are unchanged. This is a mechanical key rename done with a small Python script that also exists for the rest of the seller-data repos.

## Test plan

- [x] \`git diff --stat\` confirms only intended JSON files changed.
- [x] Spot-check diff: only the dictionary keys flip; surrounding entries identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)