### PR TITLE
Migrate from unitysvc-services to unitysvc-sellers

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install unitysvc-services
+          pip install unitysvc-sellers
 
       - name: Check formatting
         run: |
           echo "Checking data file formatting..."
-          usvc data format --check
+          usvc_seller data format --check
 
       - name: Format check summary
         if: always()
@@ -42,7 +42,7 @@ jobs:
             echo "**Formatting issues detected!**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### How to fix:" >> $GITHUB_STEP_SUMMARY
-            echo "1. Run \`usvc data format\` locally" >> $GITHUB_STEP_SUMMARY
+            echo "1. Run \`usvc_seller data format\` locally" >> $GITHUB_STEP_SUMMARY
             echo "2. Commit the formatted files" >> $GITHUB_STEP_SUMMARY
             echo "3. Push your changes" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/upload-data.yml
+++ b/.github/workflows/upload-data.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install unitysvc-services
+      - name: Install unitysvc-sellers
         run: |
           python -m pip install --upgrade pip
-          pip install unitysvc-services
+          pip install unitysvc-sellers
 
       - name: Upload services
         env:
@@ -30,7 +30,7 @@ jobs:
           UNITYSVC_API_KEY: ${{ secrets.UNITYSVC_API_KEY }}
         run: |
           echo "Uploading services..."
-          usvc services upload
+          usvc_seller services upload
 
       - name: Upload summary
         if: always()

--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -31,15 +31,15 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install unitysvc-services
+      - name: Install unitysvc-sellers
         run: |
           python -m pip install --upgrade pip
-          pip install unitysvc-services
+          pip install unitysvc-sellers
 
       - name: Validate data directory
         run: |
           echo "Validating data directory..."
-          usvc data validate
+          usvc_seller data validate
 
       - name: Data validation summary
         if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,12 @@ repos:
       - id: trailing-whitespace
         files: \.(json|md|toml)$
 
-  # Data validation using unitysvc-services
+  # Data validation using unitysvc-sellers
   - repo: local
     hooks:
       - id: validate-data-files
         name: Validate data files against schemas
-        entry: unitysvc_services validate data
+        entry: usvc_seller validate data
         language: system
         files: ^data/.*\.(json|toml|md)$
         pass_filenames: false

--- a/data/aionlabs/docs/request-template.json
+++ b/data/aionlabs/docs/request-template.json
@@ -1,13 +1,13 @@
 {
+  "max_tokens": 200,
   "messages": [
     {
-      "role": "system",
-      "content": "You are a helpful assistant."
+      "content": "You are a helpful assistant.",
+      "role": "system"
     },
     {
-      "role": "user",
-      "content": "Say this is a test"
+      "content": "Say this is a test",
+      "role": "user"
     }
-  ],
-  "max_tokens": 200
+  ]
 }

--- a/data/aionlabs/services/aion-1.0-mini/offering.json
+++ b/data/aionlabs/services/aion-1.0-mini/offering.json
@@ -1,4 +1,7 @@
 {
+  "capabilities": [
+    "llm"
+  ],
   "description": "Aion-1.0-mini is a compact, reasoning-optimized language model based on Metas LLaMA 3.1 architecture and fine-tuned by Aion Labs. Released in July 2025, it delivers efficient text generation, advanced structured reasoning, and strong coding assistance. Designed for both research and production, it supports long-context tasks and lightweight deployment.",
   "details": {
     "coding": "Strong performance on code completion and debugging tasks",
@@ -45,8 +48,5 @@
         "model": "aion-labs/aion-1.0-mini"
       }
     }
-  },
-  "capabilities": [
-    "llm"
-  ]
+  }
 }

--- a/data/aionlabs/services/aion-1.0/offering.json
+++ b/data/aionlabs/services/aion-1.0/offering.json
@@ -1,4 +1,7 @@
 {
+  "capabilities": [
+    "llm"
+  ],
   "description": "Aion-1.0 is a reasoning-optimized large language model built on Meta's LLaMA 3.1 architecture and fine-tuned by Aion Labs. Released in July 2025, it offers efficient text generation, advanced structured reasoning, and robust coding assistance. Designed for both research and production, it supports long-context understanding and lightweight deployment.",
   "details": {
     "coding": "Strong performance on code completion and debugging tasks",
@@ -45,8 +48,5 @@
         "model": "aion-labs/aion-1.0"
       }
     }
-  },
-  "capabilities": [
-    "llm"
-  ]
+  }
 }

--- a/data/aionlabs/services/aion-rp-llama-3.1-8b/offering.json
+++ b/data/aionlabs/services/aion-rp-llama-3.1-8b/offering.json
@@ -1,4 +1,7 @@
 {
+  "capabilities": [
+    "llm"
+  ],
   "description": "Aion RP LLaMA 3.1 8B is a reasoning-optimized large language model released in July 2025. It is built on Meta's LLaMA 3.1 architecture and fine-tuned by Aion Labs for efficient text generation, structured reasoning, and lightweight deployment. Designed for research and production, it supports long-context understanding, coding assistance, and advanced conversation flows.",
   "details": {
     "coding": "Strong performance on code completion and debugging tasks",
@@ -45,8 +48,5 @@
         "model": "aion-labs/aion-rp-llama-3.1-8b"
       }
     }
-  },
-  "capabilities": [
-    "llm"
-  ]
+  }
 }


### PR DESCRIPTION
## Summary

`unitysvc-services` is deprecated and has been split into [`unitysvc-core`](https://github.com/unitysvc/unitysvc-core) (shared models / validators) and [`unitysvc-sellers`](https://github.com/unitysvc/unitysvc-sellers) (the seller CLI). Update this repo's automation to use the new packages:

- **CI workflows:** install `unitysvc-sellers` and call the new `usvc_seller` entry point.
- **pre-commit:** run `usvc_seller validate data`.
- **update_services.py:** import from `unitysvc_sellers.model_data` / `unitysvc_sellers.template_populate`.
- **requirements.txt:** drop the deprecated `unitysvc-services` dependency.

This was a local commit prepared on 2026-04-12 that wasn't pushed before the recent slug-rename PRs landed; rebased cleanly onto current `main`. Includes a follow-up commit absorbing pre-existing format drift caught by the new `usvc_seller data format --check` hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)