### PR TITLE
fix: add context_length and parameter_count to LLM offerings

### DIFF
--- a/data/aionlabs/services/aion-1.0-mini/listing.json
+++ b/data/aionlabs/services/aion-1.0-mini/listing.json
@@ -29,33 +29,33 @@
     },
     "Default request body": {
       "$doc_preset": {
-        "name": "llm_request_template",
         "description": "Default request body for the playground",
-        "is_public": true
+        "is_public": true,
+        "name": "llm_request_template"
       }
     },
     "How to use this model": {
       "$doc_preset": {
-        "name": "llm_description",
-        "description": "Documentation on how to use the Aion Labs model"
+        "description": "Documentation on how to use the Aion Labs model",
+        "name": "llm_description"
       }
     },
     "JavaScript code example": {
       "$doc_preset": {
-        "name": "llm_code_example_javascript",
         "description": "Example code to use the model",
         "meta": {
           "skip_test": true
-        }
+        },
+        "name": "llm_code_example_javascript"
       }
     },
     "Python code example": {
       "$doc_preset": {
-        "name": "llm_code_example_openai",
         "description": "Example code to use the model",
         "meta": {
           "skip_test": true
-        }
+        },
+        "name": "llm_code_example_openai"
       }
     },
     "Python function calling code example": {
@@ -74,11 +74,11 @@
     },
     "cURL code example": {
       "$doc_preset": {
-        "name": "llm_code_example_shell",
         "description": "Example curl request for the model",
         "meta": {
           "output_contains": "this is a test"
-        }
+        },
+        "name": "llm_code_example_shell"
       }
     }
   },

--- a/data/aionlabs/services/aion-1.0-mini/offering.json
+++ b/data/aionlabs/services/aion-1.0-mini/offering.json
@@ -8,8 +8,10 @@
     "context_window": "131072",
     "function_calling": "Supports API-based function calling for tool use",
     "model_name": "aion-labs/aion-1.0-mini",
-    "multimodal": "Not multimodal \u2014 optimized for text-only tasks",
-    "reasoning": "Enhanced structured reasoning and step-by-step problem solving"
+    "multimodal": "Not multimodal — optimized for text-only tasks",
+    "reasoning": "Enhanced structured reasoning and step-by-step problem solving",
+    "context_length": 131072,
+    "parameter_count": null
   },
   "name": "aion-1.0-mini",
   "payout_price": {

--- a/data/aionlabs/services/aion-1.0-mini/offering.json
+++ b/data/aionlabs/services/aion-1.0-mini/offering.json
@@ -5,13 +5,13 @@
   "description": "Aion-1.0-mini is a compact, reasoning-optimized language model based on Metas LLaMA 3.1 architecture and fine-tuned by Aion Labs. Released in July 2025, it delivers efficient text generation, advanced structured reasoning, and strong coding assistance. Designed for both research and production, it supports long-context tasks and lightweight deployment.",
   "details": {
     "coding": "Strong performance on code completion and debugging tasks",
+    "context_length": 131072,
     "context_window": "131072",
     "function_calling": "Supports API-based function calling for tool use",
     "model_name": "aion-labs/aion-1.0-mini",
-    "multimodal": "Not multimodal — optimized for text-only tasks",
-    "reasoning": "Enhanced structured reasoning and step-by-step problem solving",
-    "context_length": 131072,
-    "parameter_count": null
+    "multimodal": "Not multimodal \u2014 optimized for text-only tasks",
+    "parameter_count": null,
+    "reasoning": "Enhanced structured reasoning and step-by-step problem solving"
   },
   "name": "aion-1.0-mini",
   "payout_price": {

--- a/data/aionlabs/services/aion-1.0/listing.json
+++ b/data/aionlabs/services/aion-1.0/listing.json
@@ -29,33 +29,33 @@
     },
     "Default request body": {
       "$doc_preset": {
-        "name": "llm_request_template",
         "description": "Default request body for the playground",
-        "is_public": true
+        "is_public": true,
+        "name": "llm_request_template"
       }
     },
     "How to use this model": {
       "$doc_preset": {
-        "name": "llm_description",
-        "description": "Documentation on how to use the Aion Labs model"
+        "description": "Documentation on how to use the Aion Labs model",
+        "name": "llm_description"
       }
     },
     "JavaScript code example": {
       "$doc_preset": {
-        "name": "llm_code_example_javascript",
         "description": "Example code to use the model",
         "meta": {
           "skip_test": true
-        }
+        },
+        "name": "llm_code_example_javascript"
       }
     },
     "Python code example": {
       "$doc_preset": {
-        "name": "llm_code_example_openai",
         "description": "Example code to use the model",
         "meta": {
           "skip_test": true
-        }
+        },
+        "name": "llm_code_example_openai"
       }
     },
     "Python function calling code example": {
@@ -74,11 +74,11 @@
     },
     "cURL code example": {
       "$doc_preset": {
-        "name": "llm_code_example_shell",
         "description": "Example curl request for the model",
         "meta": {
           "output_contains": "this is a test"
-        }
+        },
+        "name": "llm_code_example_shell"
       }
     }
   },

--- a/data/aionlabs/services/aion-1.0/offering.json
+++ b/data/aionlabs/services/aion-1.0/offering.json
@@ -5,13 +5,13 @@
   "description": "Aion-1.0 is a reasoning-optimized large language model built on Meta's LLaMA 3.1 architecture and fine-tuned by Aion Labs. Released in July 2025, it offers efficient text generation, advanced structured reasoning, and robust coding assistance. Designed for both research and production, it supports long-context understanding and lightweight deployment.",
   "details": {
     "coding": "Strong performance on code completion and debugging tasks",
+    "context_length": 131072,
     "context_window": "131072",
     "function_calling": "Supports API-based function calling for tool use",
     "model_name": "aion-labs/aion-1.0",
-    "multimodal": "Not multimodal — optimized for text-only tasks",
-    "reasoning": "Enhanced structured reasoning and step-by-step problem solving",
-    "context_length": 131072,
-    "parameter_count": null
+    "multimodal": "Not multimodal \u2014 optimized for text-only tasks",
+    "parameter_count": null,
+    "reasoning": "Enhanced structured reasoning and step-by-step problem solving"
   },
   "name": "aion-1.0",
   "payout_price": {

--- a/data/aionlabs/services/aion-1.0/offering.json
+++ b/data/aionlabs/services/aion-1.0/offering.json
@@ -8,8 +8,10 @@
     "context_window": "131072",
     "function_calling": "Supports API-based function calling for tool use",
     "model_name": "aion-labs/aion-1.0",
-    "multimodal": "Not multimodal \u2014 optimized for text-only tasks",
-    "reasoning": "Enhanced structured reasoning and step-by-step problem solving"
+    "multimodal": "Not multimodal — optimized for text-only tasks",
+    "reasoning": "Enhanced structured reasoning and step-by-step problem solving",
+    "context_length": 131072,
+    "parameter_count": null
   },
   "name": "aion-1.0",
   "payout_price": {

--- a/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
+++ b/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
@@ -29,33 +29,33 @@
     },
     "Default request body": {
       "$doc_preset": {
-        "name": "llm_request_template",
         "description": "Default request body for the playground",
-        "is_public": true
+        "is_public": true,
+        "name": "llm_request_template"
       }
     },
     "How to use this model": {
       "$doc_preset": {
-        "name": "llm_description",
-        "description": "Documentation on how to use the Aion Labs model"
+        "description": "Documentation on how to use the Aion Labs model",
+        "name": "llm_description"
       }
     },
     "JavaScript code example": {
       "$doc_preset": {
-        "name": "llm_code_example_javascript",
         "description": "Example code to use the model",
         "meta": {
           "skip_test": true
-        }
+        },
+        "name": "llm_code_example_javascript"
       }
     },
     "Python code example": {
       "$doc_preset": {
-        "name": "llm_code_example_openai",
         "description": "Example code to use the model",
         "meta": {
           "skip_test": true
-        }
+        },
+        "name": "llm_code_example_openai"
       }
     },
     "Python function calling code example": {
@@ -74,11 +74,11 @@
     },
     "cURL code example": {
       "$doc_preset": {
-        "name": "llm_code_example_shell",
         "description": "Example curl request for the model",
         "meta": {
           "output_contains": "this is a test"
-        }
+        },
+        "name": "llm_code_example_shell"
       }
     }
   },

--- a/data/aionlabs/services/aion-rp-llama-3.1-8b/offering.json
+++ b/data/aionlabs/services/aion-rp-llama-3.1-8b/offering.json
@@ -8,8 +8,10 @@
     "context_window": "32768",
     "function_calling": "Supports API-based function calling for tool use",
     "model_name": "aion-labs/aion-rp-llama-3.1-8b",
-    "multimodal": "Not multimodal \u2014 optimized for text-only tasks",
-    "reasoning": "Enhanced structured reasoning and step-by-step problem solving"
+    "multimodal": "Not multimodal — optimized for text-only tasks",
+    "reasoning": "Enhanced structured reasoning and step-by-step problem solving",
+    "context_length": 32768,
+    "parameter_count": 8000000000
   },
   "name": "aion-rp-llama-3.1-8b",
   "payout_price": {

--- a/data/aionlabs/services/aion-rp-llama-3.1-8b/offering.json
+++ b/data/aionlabs/services/aion-rp-llama-3.1-8b/offering.json
@@ -5,13 +5,13 @@
   "description": "Aion RP LLaMA 3.1 8B is a reasoning-optimized large language model released in July 2025. It is built on Meta's LLaMA 3.1 architecture and fine-tuned by Aion Labs for efficient text generation, structured reasoning, and lightweight deployment. Designed for research and production, it supports long-context understanding, coding assistance, and advanced conversation flows.",
   "details": {
     "coding": "Strong performance on code completion and debugging tasks",
+    "context_length": 32768,
     "context_window": "32768",
     "function_calling": "Supports API-based function calling for tool use",
     "model_name": "aion-labs/aion-rp-llama-3.1-8b",
-    "multimodal": "Not multimodal — optimized for text-only tasks",
-    "reasoning": "Enhanced structured reasoning and step-by-step problem solving",
-    "context_length": 32768,
-    "parameter_count": 8000000000
+    "multimodal": "Not multimodal \u2014 optimized for text-only tasks",
+    "parameter_count": 8000000000,
+    "reasoning": "Enhanced structured reasoning and step-by-step problem solving"
   },
   "name": "aion-rp-llama-3.1-8b",
   "payout_price": {


### PR DESCRIPTION
## Summary

- Adds `context_length` and `parameter_count` to 3 LLM offerings to satisfy the updated [unitysvc-core validation](https://github.com/unitysvc/unitysvc-core/pull/10)
- aion-1.0 and aion-1.0-mini: `context_length=131072`, `parameter_count=null` (not publicly disclosed)
- aion-rp-llama-3.1-8b: `context_length=32768`, `parameter_count=8000000000` (LLaMA 3.1 8B architecture)

## Test plan

- [x] `usvc_seller data validate` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)