### PR TITLE
code examples: migrate to {{ service_base_url }} / {{ routing_key.model }}

### DIFF
--- a/data/aionlabs/docs/code-example-fc.py.j2
+++ b/data/aionlabs/docs/code-example-fc.py.j2
@@ -5,7 +5,7 @@ import json
 # Initialize client
 client = OpenAI(
     api_key=os.environ.get("UNITYSVC_API_KEY"),
-    base_url=os.environ.get("SERVICE_BASE_URL")  # can be left blank if using default OpenAI endpoint
+    base_url="{{ service_base_url }}"  # can be left blank if using default OpenAI endpoint
 )
 
 # Example function
@@ -14,7 +14,7 @@ def echo_message(message):
 
 # Create the chat completion request
 response = client.chat.completions.create(
-    model=os.environ.get("MODEL", "{{ offering.details.model_name }}"),  # keep this template!
+    model="{{ routing_key.model }}",  # keep this template!
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "This is a test"}

--- a/data/aionlabs/docs/connectivity.sh.j2
+++ b/data/aionlabs/docs/connectivity.sh.j2
@@ -1,9 +1,9 @@
-curl "$SERVICE_BASE_URL/chat/completions" \
+curl "{{ service_base_url }}/chat/completions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $UNITYSVC_API_KEY" \
   -d @- <<EOF
 {
-  "model": "${MODEL:-{{ offering.details.model_name }}}",
+  "model": "{{ routing_key.model }}}}",
   "messages": [
     {
       "role": "system",


### PR DESCRIPTION
## Summary

Migrate every code-example / connectivity-test `.j2` template in this repo from process-environment lookups to the platform's Jinja2 placeholders, matching the convention adopted across [unitysvc-data](https://github.com/unitysvc/unitysvc-data) ([unitysvc-data#15](https://github.com/unitysvc/unitysvc-data/pull/15)) and now expected by the seller-side renderer + the new public marketplace render endpoint ([unitysvc/unitysvc#892](https://github.com/unitysvc/unitysvc/pull/892)):

| Before | After |
|---|---|
| `os.environ["SERVICE_BASE_URL"]` / `os.environ.get("SERVICE_BASE_URL", ...)` | `"{{ service_base_url }}"` |
| `os.environ["MODEL"]` / `os.environ.get("MODEL", ...)` | `"{{ routing_key.model }}"` |
| `process.env.SERVICE_BASE_URL` (with optional `\|\|` fallback) | `"{{ service_base_url }}"` |
| `process.env.MODEL` (with optional `\|\|` fallback) | `"{{ routing_key.model }}"` |
| `${SERVICE_BASE_URL}` / `${SERVICE_BASE_URL:?...}` / `$SERVICE_BASE_URL` (shell) | `{{ service_base_url }}` |
| `${MODEL}` / `${MODEL:?...}` / `$MODEL` (shell) | `{{ routing_key.model }}` |
| `: "${SERVICE_BASE_URL:?msg}"` defensive checks | dropped (rendered values are inlined) |
| `os.environ["UNITYSVC_API_KEY"]` etc. | **unchanged** — keys never inline into rendered output |

## Why this is needed

Until now, code examples on the marketplace's service-detail page were displayed as raw template source: customers saw literal `{{ service_base_url }}` placeholders if the template used the new convention, or runnable scripts that required them to set obscure env vars manually if the template used the old `os.environ.get(...)` form.

The platform's new flow ([#877](https://github.com/unitysvc/unitysvc/issues/877) → [#892](https://github.com/unitysvc/unitysvc/pull/892)) renders templates server-side per access-interface so the customer-displayed code is fully resolved (gateway URL substituted, model name inlined, API key still env-var since it's per-customer). Templates that read `SERVICE_BASE_URL` / `MODEL` from `os.environ` instead of using the placeholders bypass that path and stay broken on the marketplace.

## Scope

Only `.j2` files under `data/` were touched, and only `MODEL` / `SERVICE_BASE_URL` references. `UNITYSVC_API_KEY` stays as an env-var lookup (intentional — keys are never inlined into rendered output, on any code path). No structural rewrites — the alias declarations and code shape are preserved; the goal here is a mechanical substitution that humans can review in one diff.

## Test plan

- [x] `usvc_seller data validate data` passes
- [x] No remaining `os.environ.*SERVICE_BASE_URL` / `os.environ.*MODEL` / `process.env.{SERVICE_BASE_URL,MODEL}` / `$SERVICE_BASE_URL` / `$MODEL` references in `.j2` files (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
