### PR TITLE
listings: drop redundant is_public:true overrides on $doc_preset

### DIFF
--- a/data/aionlabs/services/aion-1.0-mini/listing.json
+++ b/data/aionlabs/services/aion-1.0-mini/listing.json
@@ -23,10 +23,7 @@
       }
     },
     "Default request body": {
-      "$doc_preset": {
-        "is_public": true,
-        "name": "llm_request_template"
-      }
+      "$doc_preset": "llm_request_template"
     },
     "How to use this model": {
       "$doc_preset": "llm_description"

--- a/data/aionlabs/services/aion-1.0/listing.json
+++ b/data/aionlabs/services/aion-1.0/listing.json
@@ -23,10 +23,7 @@
       }
     },
     "Default request body": {
-      "$doc_preset": {
-        "is_public": true,
-        "name": "llm_request_template"
-      }
+      "$doc_preset": "llm_request_template"
     },
     "How to use this model": {
       "$doc_preset": "llm_description"

--- a/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
+++ b/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
@@ -23,10 +23,7 @@
       }
     },
     "Default request body": {
-      "$doc_preset": {
-        "is_public": true,
-        "name": "llm_request_template"
-      }
+      "$doc_preset": "llm_request_template"
     },
     "How to use this model": {
       "$doc_preset": "llm_description"


### PR DESCRIPTION
## Summary

Mechanical sweep: every preset is already `is_public: true` since [unitysvc-data 0.1.9](https://github.com/unitysvc/unitysvc-data/releases/tag/v0.1.9), so an explicit `is_public: true` override on a `$doc_preset` block is just noise. Drop it; if `name` is the only field left, collapse to the bare-string form `"$doc_preset": "<preset_name>"`.

`is_public: false` overrides (genuinely making a doc private) are preserved — they still flip the default.

## Test plan

- [x] `usvc_seller data validate` passes