### PR TITLE
listings: switch LLM connectivity to llm_connectivity, drop dead skip_test

### DIFF
--- a/data/aionlabs/services/aion-1.0-mini/listing.json
+++ b/data/aionlabs/services/aion-1.0-mini/listing.json
@@ -19,7 +19,7 @@
     "Connectivity test": {
       "$doc_preset": {
         "is_public": false,
-        "name": "api_connectivity"
+        "name": "llm_connectivity"
       }
     },
     "Default request body": {
@@ -32,28 +32,13 @@
       "$doc_preset": "llm_description"
     },
     "JavaScript code example": {
-      "$doc_preset": {
-        "meta": {
-          "skip_test": true
-        },
-        "name": "llm_code_example_javascript"
-      }
+      "$doc_preset": "llm_code_example_javascript"
     },
     "Python code example": {
-      "$doc_preset": {
-        "meta": {
-          "skip_test": true
-        },
-        "name": "llm_code_example_openai"
-      }
+      "$doc_preset": "llm_code_example_openai"
     },
     "Python function calling code example": {
-      "$doc_preset": {
-        "meta": {
-          "skip_test": true
-        },
-        "name": "llm_code_example_fc_requests"
-      }
+      "$doc_preset": "llm_code_example_fc_requests"
     },
     "cURL code example": {
       "$doc_preset": "llm_code_example_shell"

--- a/data/aionlabs/services/aion-1.0/listing.json
+++ b/data/aionlabs/services/aion-1.0/listing.json
@@ -19,7 +19,7 @@
     "Connectivity test": {
       "$doc_preset": {
         "is_public": false,
-        "name": "api_connectivity"
+        "name": "llm_connectivity"
       }
     },
     "Default request body": {
@@ -32,28 +32,13 @@
       "$doc_preset": "llm_description"
     },
     "JavaScript code example": {
-      "$doc_preset": {
-        "meta": {
-          "skip_test": true
-        },
-        "name": "llm_code_example_javascript"
-      }
+      "$doc_preset": "llm_code_example_javascript"
     },
     "Python code example": {
-      "$doc_preset": {
-        "meta": {
-          "skip_test": true
-        },
-        "name": "llm_code_example_openai"
-      }
+      "$doc_preset": "llm_code_example_openai"
     },
     "Python function calling code example": {
-      "$doc_preset": {
-        "meta": {
-          "skip_test": true
-        },
-        "name": "llm_code_example_fc_requests"
-      }
+      "$doc_preset": "llm_code_example_fc_requests"
     },
     "cURL code example": {
       "$doc_preset": "llm_code_example_shell"

--- a/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
+++ b/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
@@ -19,7 +19,7 @@
     "Connectivity test": {
       "$doc_preset": {
         "is_public": false,
-        "name": "api_connectivity"
+        "name": "llm_connectivity"
       }
     },
     "Default request body": {
@@ -32,28 +32,13 @@
       "$doc_preset": "llm_description"
     },
     "JavaScript code example": {
-      "$doc_preset": {
-        "meta": {
-          "skip_test": true
-        },
-        "name": "llm_code_example_javascript"
-      }
+      "$doc_preset": "llm_code_example_javascript"
     },
     "Python code example": {
-      "$doc_preset": {
-        "meta": {
-          "skip_test": true
-        },
-        "name": "llm_code_example_openai"
-      }
+      "$doc_preset": "llm_code_example_openai"
     },
     "Python function calling code example": {
-      "$doc_preset": {
-        "meta": {
-          "skip_test": true
-        },
-        "name": "llm_code_example_fc_requests"
-      }
+      "$doc_preset": "llm_code_example_fc_requests"
     },
     "cURL code example": {
       "$doc_preset": "llm_code_example_shell"


### PR DESCRIPTION
## Summary

Two mechanical sweeps over every `listing.json` that's LLM-shaped (has `routing_key.model`):

### 1. `api_connectivity` → `llm_connectivity`

`api_connectivity` is a generic GET-the-URL probe. For an LLM service it tells you nothing useful — only "the gateway is alive". The new `llm_connectivity` preset (in [unitysvc-data#23](https://github.com/unitysvc/unitysvc-data/pull/23)) POSTs a one-token chat completion against `{{ routing_key.model }}` and asserts a real `choices` array came back, so the customer / run-tests / marketplace can tell that the gateway *and* the model are both healthy.

### 2. Drop `meta.skip_test: true` overrides

`skip_test` isn't a recognized platform meta key — the run-tests flow ignores it (verified by experiment: presets with `skip_test: true` were running anyway). Code examples should run unless they need a niche dep the platform's test environment doesn't install; the recognized "skip" shape is `meta.test.status: "skip"`, which is left alone.

After the strips, if the `$doc_preset` override block has only `name` left, it collapses to the bare-string form `"$doc_preset": "<preset>"`.

## Dependency

This PR depends on [unitysvc-data#23](https://github.com/unitysvc/unitysvc-data/pull/23) (adds `llm_connectivity`) being released before the published seller CLI can resolve the new preset name.

## Test plan

- [x] `usvc_seller data validate` passes (verified locally with editable `unitysvc-data` branch).
