### PR TITLE
upload-data: fix secret names + renamed submit flag

### DIFF
--- a/.github/workflows/upload-data.yml
+++ b/.github/workflows/upload-data.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Upload services
         env:
-          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_API_KEY }}
-          UNITYSVC_SELLER_API_URL: ${{ secrets.SERVICE_API_URL }}
+          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
+          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
         run: |
           echo "Uploading services..."
           usvc_seller data upload
@@ -48,11 +48,11 @@ jobs:
 
       - name: Submit services for review
         env:
-          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_API_KEY }}
-          UNITYSVC_SELLER_API_URL: ${{ secrets.SERVICE_API_URL }}
+          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
+          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
         run: |
           echo "Submitting services for review..."
-          usvc_seller services submit --from-data --data-dir data --yes
+          usvc_seller services submit --local-ids --data-dir data --yes
 
       - name: Upload summary
         if: always()


### PR DESCRIPTION
## Summary

Two follow-on fixes that landed on `unitysvc-services-template` (PRs [#27](https://github.com/unitysvc-labs/unitysvc-services-template/pull/27) + [#28](https://github.com/unitysvc-labs/unitysvc-services-template/pull/28)) and now need to land on every other seller-data repo using the same `upload-data.yml` shape.

### 1. Secret names (always applies)

The workflow was reading `secrets.UNITYSVC_API_KEY` and `secrets.SERVICE_API_URL`, then renaming into the env vars the seller CLI expects. The org-level secrets are stored under their canonical `UNITYSVC_SELLER_*` names directly, so the rename resolved to empty values and every recent merge produced:

```
✗ Missing seller API key. Set $UNITYSVC_SELLER_API_KEY or pass --api-key.
```

```diff
-          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_API_KEY }}
-          UNITYSVC_SELLER_API_URL: ${{ secrets.SERVICE_API_URL }}
+          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
+          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
```

### 2. `--from-data` → `--local-ids` (where the workflow has a submit step)

The seller CLI renamed `usvc_seller services submit --from-data` → `--local-ids` (`-l`). Only applied to repos whose `upload-data.yml` uses the option.

## Verified on `unitysvc-services-template`

The merge of [#27](https://github.com/unitysvc-labs/unitysvc-services-template/pull/27) successfully ingested all 16 demo services with the corrected secret names; [#28](https://github.com/unitysvc-labs/unitysvc-services-template/pull/28) caught the submit-flag rename right after.
