### PR TITLE
upstream: drop /v1 from offering base_url (symmetric-move convention)

### DIFF
--- a/data/aionlabs/services/aion-1.0-mini/offering.json
+++ b/data/aionlabs/services/aion-1.0-mini/offering.json
@@ -9,7 +9,7 @@
     "context_window": "131072",
     "function_calling": "Supports API-based function calling for tool use",
     "model_name": "aion-labs/aion-1.0-mini",
-    "multimodal": "Not multimodal \u2014 optimized for text-only tasks",
+    "multimodal": "Not multimodal — optimized for text-only tasks",
     "parameter_count": null,
     "reasoning": "Enhanced structured reasoning and step-by-step problem solving"
   },
@@ -31,7 +31,7 @@
     "aion_labs_api": {
       "access_method": "http",
       "api_key": "${ secrets.AIONLABS_API_KEY }",
-      "base_url": "https://api.aionlabs.ai/v1",
+      "base_url": "https://api.aionlabs.ai",
       "rate_limits": [
         {
           "description": "API request rate limit",

--- a/data/aionlabs/services/aion-1.0/offering.json
+++ b/data/aionlabs/services/aion-1.0/offering.json
@@ -9,7 +9,7 @@
     "context_window": "131072",
     "function_calling": "Supports API-based function calling for tool use",
     "model_name": "aion-labs/aion-1.0",
-    "multimodal": "Not multimodal \u2014 optimized for text-only tasks",
+    "multimodal": "Not multimodal — optimized for text-only tasks",
     "parameter_count": null,
     "reasoning": "Enhanced structured reasoning and step-by-step problem solving"
   },
@@ -31,7 +31,7 @@
     "aion_labs_api": {
       "access_method": "http",
       "api_key": "${ secrets.AIONLABS_API_KEY }",
-      "base_url": "https://api.aionlabs.ai/v1",
+      "base_url": "https://api.aionlabs.ai",
       "rate_limits": [
         {
           "description": "API request rate limit",

--- a/data/aionlabs/services/aion-rp-llama-3.1-8b/offering.json
+++ b/data/aionlabs/services/aion-rp-llama-3.1-8b/offering.json
@@ -9,7 +9,7 @@
     "context_window": "32768",
     "function_calling": "Supports API-based function calling for tool use",
     "model_name": "aion-labs/aion-rp-llama-3.1-8b",
-    "multimodal": "Not multimodal \u2014 optimized for text-only tasks",
+    "multimodal": "Not multimodal — optimized for text-only tasks",
     "parameter_count": 8000000000,
     "reasoning": "Enhanced structured reasoning and step-by-step problem solving"
   },
@@ -31,7 +31,7 @@
     "aion_labs_api": {
       "access_method": "http",
       "api_key": "${ secrets.AIONLABS_API_KEY }",
-      "base_url": "https://api.aionlabs.ai/v1",
+      "base_url": "https://api.aionlabs.ai",
       "rate_limits": [
         {
           "description": "API request rate limit",


### PR DESCRIPTION
## Summary

Drops `/v1` from `upstream_access_config.<iface>.base_url` in every offering as part of the symmetric-move convention: every layer (listing user-side, upstream, env vars) keeps the bare provider host without a version segment, and the `/v1/...` path is added by the SDK or the preset that constructs the URL.

After this PR, `/v1` is no longer baked into the upstream URL the gateway forwards to. The gateway routes the customer-side `/p/<provider>/v1/<endpoint>` request through and the trailing `/v1/<endpoint>` concatenates onto the upstream's bare host:

```
customer (any SDK)  →  POST <gw>/p/<provider>/v1/chat/completions
gateway forwards to →  POST https://api.<provider>.com/v1/chat/completions
```

## Implementation note

For repos where the offering template uses `{{ api_base_url }}` (the
script-constant pattern), the strip happens at the **template** layer
via the Jinja `replace("/v1", "")` filter — keeping the script's
`API_BASE_URL` constant intact (the script still needs `/v1` for its
own `/models` discovery call). For other shapes (template literal,
script literal, hand-curated), the edit happens wherever the `/v1`
literally lives.

## Dependency

The matching customer-side change lands in `unitysvc-data` — OpenAI-shape presets (`llm_code_example_openai`, `llm_code_example_requests`, `llm_code_example_shell`, `llm_code_example_javascript`, `llm_code_example_fc_requests`, `llm_connectivity`, `llm_connectivity_embed`) are updated to construct paths starting with `/v1/`. **Do not merge this PR until the new `unitysvc-data` is released**, otherwise OpenAI-shape examples in published listings 404 in the gap. The `Cerebras` / `Anthropic` / `Cohere v2` SDK presets stay bare (those SDKs hardcode their own `/v1/...`).

## Test plan

- [x] `usvc_seller data populate` regenerates offerings with the bare upstream
- [x] `usvc_seller data validate` clean
- [ ] CI
- [ ] After merge: upload-data workflow uploads the new offering data to the backend
