### PR TITLE
chore: normalize JSON formatting

### DIFF
--- a/data/aionlabs/services/aion-1.0-mini/offering.json
+++ b/data/aionlabs/services/aion-1.0-mini/offering.json
@@ -9,7 +9,7 @@
     "context_window": "131072",
     "function_calling": "Supports API-based function calling for tool use",
     "model_name": "aion-labs/aion-1.0-mini",
-    "multimodal": "Not multimodal — optimized for text-only tasks",
+    "multimodal": "Not multimodal \u2014 optimized for text-only tasks",
     "parameter_count": null,
     "reasoning": "Enhanced structured reasoning and step-by-step problem solving"
   },

--- a/data/aionlabs/services/aion-1.0/offering.json
+++ b/data/aionlabs/services/aion-1.0/offering.json
@@ -9,7 +9,7 @@
     "context_window": "131072",
     "function_calling": "Supports API-based function calling for tool use",
     "model_name": "aion-labs/aion-1.0",
-    "multimodal": "Not multimodal — optimized for text-only tasks",
+    "multimodal": "Not multimodal \u2014 optimized for text-only tasks",
     "parameter_count": null,
     "reasoning": "Enhanced structured reasoning and step-by-step problem solving"
   },

--- a/data/aionlabs/services/aion-rp-llama-3.1-8b/offering.json
+++ b/data/aionlabs/services/aion-rp-llama-3.1-8b/offering.json
@@ -9,7 +9,7 @@
     "context_window": "32768",
     "function_calling": "Supports API-based function calling for tool use",
     "model_name": "aion-labs/aion-rp-llama-3.1-8b",
-    "multimodal": "Not multimodal — optimized for text-only tasks",
+    "multimodal": "Not multimodal \u2014 optimized for text-only tasks",
     "parameter_count": 8000000000,
     "reasoning": "Enhanced structured reasoning and step-by-step problem solving"
   },


### PR DESCRIPTION
Run `usvc_seller data format` to fix JSON formatting drift flagged by the Check Code Formatting workflow on `main` after #12 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)