### PR TITLE
ci: split upload workflow into staging and production

### DIFF
--- a/.github/workflows/upload-to-production.yml
+++ b/.github/workflows/upload-to-production.yml
@@ -1,0 +1,60 @@
+name: Upload Data to Production
+
+# Manual-only: production uploads are deliberate, never PR-triggered.
+# Assumes service IDs already exist in production (created by an earlier
+# staging run; this repo's *.override.{json,toml} files carry those IDs).
+# This workflow therefore does NOT write back override files — those are
+# managed exclusively by the staging workflow.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install unitysvc-sellers
+        run: |
+          python -m pip install --upgrade pip
+          pip install unitysvc-sellers
+
+      - name: Upload services
+        env:
+          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_PRODUCTION_API_KEY }}
+          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_PRODUCTION_API_URL }}
+        run: |
+          echo "Uploading services to production..."
+          usvc_seller data upload
+
+      - name: Publish services
+        env:
+          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_PRODUCTION_API_KEY }}
+          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_PRODUCTION_API_URL }}
+        run: |
+          echo "Publishing services to make them visible in the catalog..."
+          usvc_seller services set-visibility public --local-ids --data-dir data --yes
+
+      - name: Submit services for review
+        env:
+          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_PRODUCTION_API_KEY }}
+          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_PRODUCTION_API_URL }}
+        run: |
+          echo "Submitting services for review..."
+          usvc_seller services submit --local-ids --data-dir data --yes
+
+      - name: Upload summary
+        if: always()
+        run: |
+          echo "## Upload Summary (Production)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Uploaded to Backend" >> $GITHUB_STEP_SUMMARY
+          echo "- Backend URL: \`${{ secrets.UNITYSVC_SELLER_PRODUCTION_API_URL }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Triggered manually by: @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/upload-to-staging.yml
+++ b/.github/workflows/upload-to-staging.yml
@@ -1,4 +1,4 @@
-name: Upload Data
+name: Upload Data to Staging
 
 on:
   pull_request:
@@ -28,10 +28,10 @@ jobs:
 
       - name: Upload services
         env:
-          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
-          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
+          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_STAGING_API_KEY }}
+          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_STAGING_API_URL }}
         run: |
-          echo "Uploading services..."
+          echo "Uploading services to staging..."
           usvc_seller data upload
 
       - name: Commit back override files
@@ -48,16 +48,16 @@ jobs:
 
       - name: Publish services
         env:
-          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
-          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
+          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_STAGING_API_KEY }}
+          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_STAGING_API_URL }}
         run: |
           echo "Publishing services to make them visible in the catalog..."
           usvc_seller services set-visibility public --local-ids --data-dir data --yes
 
       - name: Submit services for review
         env:
-          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
-          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
+          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_STAGING_API_KEY }}
+          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_STAGING_API_URL }}
         run: |
           echo "Submitting services for review..."
           usvc_seller services submit --local-ids --data-dir data --yes
@@ -65,8 +65,8 @@ jobs:
       - name: Upload summary
         if: always()
         run: |
-          echo "## Upload Summary" >> $GITHUB_STEP_SUMMARY
+          echo "## Upload Summary (Staging)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Uploaded to Backend" >> $GITHUB_STEP_SUMMARY
-          echo "- Backend URL: \`${{ secrets.SERVICE_API_URL }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Backend URL: \`${{ secrets.UNITYSVC_SELLER_STAGING_API_URL }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Triggered by PR: #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Rename `upload-data.yml` → `upload-to-staging.yml` and switch its secrets to `UNITYSVC_SELLER_STAGING_API_{KEY,URL}`.
- Add `upload-to-production.yml` — `workflow_dispatch` only, uses `UNITYSVC_SELLER_PRODUCTION_API_{KEY,URL}`, and deliberately omits the override-file commit-back step.

## Why
The existing upload runs on PR-merge and is the only path to either backend. Splitting it lets staging keep the auto-on-merge behavior (and the override-file write-back that captures service IDs) while production becomes a deliberate, manually-invoked promotion. Production trusts the override files already in main from a prior staging run, so it never writes IDs back.

## Required before merge
Add four secrets to this repo (or to the unitysvc-labs org):
- `UNITYSVC_SELLER_STAGING_API_KEY` — same value as today's `UNITYSVC_SELLER_API_KEY`
- `UNITYSVC_SELLER_STAGING_API_URL` — same value as today's `UNITYSVC_SELLER_API_URL`
- `UNITYSVC_SELLER_PRODUCTION_API_KEY`
- `UNITYSVC_SELLER_PRODUCTION_API_URL`

Old `UNITYSVC_SELLER_API_KEY` / `UNITYSVC_SELLER_API_URL` / `SERVICE_API_URL` can be deleted once the renamed staging workflow runs cleanly post-merge.

## Test plan
- [ ] Verify the four secrets exist before merging.
- [ ] Merge a trivial data change and confirm the renamed staging workflow runs end-to-end.
- [ ] Manually dispatch `Upload Data to Production` from the Actions tab and confirm it picks up the production secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
