### PR TITLE
data: drop legacy /p/<provider> prefix from base_url

### DIFF
--- a/data/aionlabs/services/aion-1.0-mini/listing.json
+++ b/data/aionlabs/services/aion-1.0-mini/listing.json
@@ -53,7 +53,7 @@
   "user_access_interfaces": {
     "provider_api": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/p/aionlabs",
+      "base_url": "${API_GATEWAY_BASE_URL}/aionlabs",
       "routing_key": {
         "model": "aion-labs/aion-1.0-mini"
       }

--- a/data/aionlabs/services/aion-1.0/listing.json
+++ b/data/aionlabs/services/aion-1.0/listing.json
@@ -53,7 +53,7 @@
   "user_access_interfaces": {
     "provider_api": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/p/aionlabs",
+      "base_url": "${API_GATEWAY_BASE_URL}/aionlabs",
       "routing_key": {
         "model": "aion-labs/aion-1.0"
       }

--- a/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
+++ b/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
@@ -52,7 +52,7 @@
   "user_access_interfaces": {
     "provider_api": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/p/aionlabs",
+      "base_url": "${API_GATEWAY_BASE_URL}/aionlabs",
       "routing_key": {
         "model": "aion-labs/aion-rp-llama-3.1-8b"
       }


### PR DESCRIPTION
## Summary

Drops the legacy `/p/<provider>` prefix from `${API_GATEWAY_BASE_URL}/...` paths in `user_access_interfaces.<key>.base_url` across this repo's listing data files.

## Why

`/p/` was documented as a primitive in [unitysvc/unitysvc#1131](https://github.com/unitysvc/unitysvc/issues/1131) but never actually dispatched by the gateway — `svcpass.lua` strips only wrapper-stack prefixes (`l/ m/ f/ t/`) and passes the remainder verbatim to the backend listing resolver. The platform service-naming convention from [unitysvc/unitysvc#1138](https://github.com/unitysvc/unitysvc/issues/1138) makes the absence of `/p/` explicit and enforces it at registration time via [unitysvc-core#16](https://github.com/unitysvc-labs/unitysvc-core/pull/16) (now released as 0.1.9).

## What changed

Mechanical substitution in every `listing*.json` / `listing*.toml` under `data/`:

```
${API_GATEWAY_BASE_URL}/p/<provider>  →  ${API_GATEWAY_BASE_URL}/<provider>
```

No other changes to listings.

## Related PRs

- [unitysvc/unitysvc#1140](https://github.com/unitysvc/unitysvc/pull/1140) — `/p/` cleanup in the backend codebase
- [unitysvc/unitysvc-core#16](https://github.com/unitysvc/unitysvc-core/pull/16) — naming-convention validator
- [unitysvc/unitysvc-sellers#59](https://github.com/unitysvc/unitysvc-sellers/pull/59) — bump `unitysvc-core` floor to `>=0.1.9`

## Test plan

- [x] `usvc_seller data validate` passes against this repo with the new validator
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
