### PR TITLE
chore: migrate to PR #1196 service-name convention

### DIFF
--- a/data/aionlabs/services/aion-1.0-mini/listing.json
+++ b/data/aionlabs/services/aion-1.0-mini/listing.json
@@ -47,13 +47,14 @@
     "output": "1.4",
     "type": "one_million_tokens"
   },
+  "name": "aionlabs/aion-1.0-mini",
   "schema": "listing_v1",
   "status": "ready",
   "time_created": "2025-08-21T00:00:00Z",
   "user_access_interfaces": {
     "provider_api": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/aionlabs",
+      "base_url": "${API_GATEWAY_BASE_URL}/{{ service_name }}",
       "routing_key": {
         "model": "aion-labs/aion-1.0-mini"
       }

--- a/data/aionlabs/services/aion-1.0/listing.json
+++ b/data/aionlabs/services/aion-1.0/listing.json
@@ -47,13 +47,14 @@
     "output": "1.4",
     "type": "one_million_tokens"
   },
+  "name": "aionlabs/aion-1.0",
   "schema": "listing_v1",
   "status": "ready",
   "time_created": "2025-08-21T00:00:00Z",
   "user_access_interfaces": {
     "provider_api": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/aionlabs",
+      "base_url": "${API_GATEWAY_BASE_URL}/{{ service_name }}",
       "routing_key": {
         "model": "aion-labs/aion-1.0"
       }

--- a/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
+++ b/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
@@ -46,13 +46,14 @@
     "price": "0.2",
     "type": "one_million_tokens"
   },
+  "name": "aionlabs/aion-rp-llama-3.1-8b",
   "schema": "listing_v1",
   "status": "ready",
   "time_created": "2025-07-15T00:00:00Z",
   "user_access_interfaces": {
     "provider_api": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/aionlabs",
+      "base_url": "${API_GATEWAY_BASE_URL}/{{ service_name }}",
       "routing_key": {
         "model": "aion-labs/aion-rp-llama-3.1-8b"
       }


### PR DESCRIPTION
## Summary
Migrates this repo to the explicit `service_name = listing.name` convention introduced by [unitysvc#1196](https://github.com/unitysvc/unitysvc/pull/1196) + unitysvc-core 0.1.15. Pre-migration every listing in the repo fails `usvc_seller data validate`.

## Source change
`listing.json.j2` template:

```diff
+  "name": "{{ provider_name }}/{{ offering_name }}",
   ...
-      "base_url": "${API_GATEWAY_BASE_URL}/{{ provider_name }}",
+      "base_url": "${API_GATEWAY_BASE_URL}/{% raw %}{{ service_name }}{% endraw %}",
```

- `name` emits the platform identifier as `<provider>/<offering>` — the bare name namespaced under the provider slug, required by the new grammar.
- `base_url` switches to the runtime `{{ service_name }}` the gateway resolves at request time. `{% raw %}…{% endraw %}` keeps it intact across the generator's render pass.

Next time `update_services.py` runs, every listing it emits will already carry the new shape.

## Generated output update
Listing files under `data/<provider>/services/` re-rendered to match the new template:

- `listing.json` — `name` added, `base_url` rewritten. Other fields (routing_key, pricing, docs) unchanged.
- `listing.override.json` — stale bare `name` updated to the new namespaced form so the merged listing reads correctly until the next upload re-pins it. `service_id` preserved untouched.

## Customer-facing URL **does** change
The resolved gateway URL gains the bare-name segment:

- **Before:** `${API_GATEWAY_BASE_URL}/<provider>` (e.g. `…/cohere`)
- **After:**  `${API_GATEWAY_BASE_URL}/<provider>/<bare>` (e.g. `…/cohere/command-a-vision-07-2025`)

The new shape is what PR #1196 mandates. Customers who were hitting the bare `/<provider>` URL may need to update their integrations; customers already hitting `<provider>/<bare>` paths should be unaffected because that's the new resolved URL.

## End-to-end behavior at upload (verified on staging — see cohere pilot)
The renamed `listing.name` is a content change on the ServiceListing row, so the backend's ingest path creates a **draft revision** keyed under each existing active service rather than updating in place. The full flow:

1. `data upload` ingests each listing. For services with a pinned `service_id` (every override), the backend matches the existing active service and creates a draft revision with the new namespaced name and base_url. The override file's `service_id` remains the **canonical (parent) id** — it is not flipped to the revision id.
2. `services submit --local-ids` resolves those canonical ids through the backend's `ids=` filter, which auto-expands to include any service whose `revision_of` matches. The CLI picks the draft revisions out of the expansion and PATCHes them to `pending` — the workflow needs no override-file rewrites for this to work.
3. Admin review (or staging's auto-approval) lands the revisions as the new active services; the originals deprecate.

The `services submit` no-op silencer in [unitysvc-sellers#62](https://github.com/unitysvc/unitysvc-sellers/pull/62) is **not** triggered here — content really did change, so the dup-content check doesn't fire and the submit goes through normally.

## Service-ID stability
Override files keep their `service_id`. The canonical service_id is preserved through the migration as the revision's parent; downstream tooling (dashboard, customer enrollment, billing) continues to reference the same id.

## Verification
- ✅ `usvc_seller data validate` clean.
- ✅ `usvc_seller data format` only touches the migrated files.
- ✅ **Cohere pilot uploaded to staging end-to-end** — 16 / 16 ingested as revisions, 16 / 16 submitted, all transitioned to `active` with the new namespaced names. This PR's repo follows the same path.

Follow-up to the [cohere pilot](https://github.com/unitysvc-labs/unitysvc-services-cohere/pull/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
