### PR TITLE
data: revert {{ service_name }} base_url; keep namespaced names

### DIFF
--- a/data/aionlabs/services/aion-1.0-mini/listing.json
+++ b/data/aionlabs/services/aion-1.0-mini/listing.json
@@ -54,7 +54,7 @@
   "user_access_interfaces": {
     "provider_api": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/{{ service_name }}",
+      "base_url": "${API_GATEWAY_BASE_URL}/aionlabs",
       "routing_key": {
         "model": "aion-labs/aion-1.0-mini"
       }

--- a/data/aionlabs/services/aion-1.0/listing.json
+++ b/data/aionlabs/services/aion-1.0/listing.json
@@ -54,7 +54,7 @@
   "user_access_interfaces": {
     "provider_api": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/{{ service_name }}",
+      "base_url": "${API_GATEWAY_BASE_URL}/aionlabs",
       "routing_key": {
         "model": "aion-labs/aion-1.0"
       }

--- a/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
+++ b/data/aionlabs/services/aion-rp-llama-3.1-8b/listing.json
@@ -53,7 +53,7 @@
   "user_access_interfaces": {
     "provider_api": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/{{ service_name }}",
+      "base_url": "${API_GATEWAY_BASE_URL}/aionlabs",
       "routing_key": {
         "model": "aion-labs/aion-rp-llama-3.1-8b"
       }


### PR DESCRIPTION
## Summary

Reverts the `base_url` portion of the PR #1196 service-name migration. That PR rewrote `base_url` to `${API_GATEWAY_BASE_URL}/{{ service_name }}`, but this provider routes all of its services through a **single** gateway `base_url` and selects the target via `routing_key`/`model`. A per-service `{{ service_name }}` path is therefore wrong — it would produce `/<provider>/<model>` instead of the served `/<provider>` path.

The platform no longer requires `{{ service_name }}` in `base_url` (see unitysvc-core [#24](https://github.com/unitysvc/unitysvc-core/pull/24)).

## What changed

- `base_url` reverted from `${API_GATEWAY_BASE_URL}/{{ service_name }}` back to the literal provider path (materialized `listing.json` + the `.j2` template).
- Dropped the now-stale `{% raw %}{{ service_name }}{% endraw %}` template wrapping and the comment claiming the gateway resolves `service_name` from `base_url`.

## What stays

- The namespaced `name` fields (`service_name = listing.name`, #1196) are **kept** — they remain valid and required (bare top-level names are admin-gated).

## Test plan

- [x] `usvc_seller data format --check` clean
- [x] No `{{ service_name }}` markers remain; gateway `base_url`s are valid under the relaxed validator (literal provider path / dynamic first segment)